### PR TITLE
Make things more suited to ES6 and add node-kafka as project dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,35 @@
 
 A quick Kafka sandbox with a small Hapi.js server and node client to listen for and handle POST requests.
 
-#Set up Kafka
+## Set up Kafka
+
 Follow the Kafka quickstart instructions [here](http://kafka.apache.org/documentation.html#quickstart).
 The code is configured to read and write into a topic called `test` which is what you create when walking through the quickstart so be sure to stick to that naming convention or remember to dive into the `producer.js` and `consumer.js` files and swap the topic names out.
 
 Once you've set up a couple of topics, you can quickly launch Kafka locally with two commands:
 
-```
+```sh
 bin/zookeeper-server-start.sh config/zookeeper.properties
 bin/kafka-server-start.sh config/server.properties
 ```
 
-#Launch Server
+## Launch Server
 
 In a new terminal window, cd to the project directory and type:
 
-```
-node server.js
+```sh
+npm install
 ```
 
-I recommend downloading [nodemon](https://github.com/remy/nodemon) and running that instead of node as it makes it a lot easier to play around. 
+Then fire up the server with:
 
-#Recieve Webhooks
+```sh
+npm start
+```
+
+> I recommend downloading [nodemon](https://github.com/remy/nodemon) and running that instead of node as it makes it a lot easier to play around. 
+
+## Recieve Webhooks
 
 I use ngrok to expose localhost. Feel free to do the same here: [ngrok](https://ngrok.com/)
 Once you've downloaded it and while you have the node server running, just open up a new terminal window and type in `ngrok 8080`. You can then use that generate url to send Webhook post data to.

--- a/consumer.js
+++ b/consumer.js
@@ -1,13 +1,17 @@
-var kafka = require('kafka-node'),
-    Consumer = kafka.Consumer,
-    client = new kafka.Client(),
-    consumer = new Consumer(
-        client,
-        [
-            { topic: 'test'}
-        ]
-    );
+'use strict';
 
-consumer.on('message', function (message) {
-    console.log(JSON.parse(message.value));
+const kafka = require('kafka-node'),
+
+const Consumer = kafka.Consumer;
+const client = new kafka.Client();
+
+const consumer = new Consumer(
+  client,
+  [
+    { topic: 'test'}
+  ]
+);
+
+consumer.on('message', message => {
+  console.log(JSON.parse(message.value));
 });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kafka-sandbox",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,6 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "hapi": "^13.4.0"
+    "hapi": "^13.4.0",
+    "kafka-node": "^1.0.1",
+    "sync-request": "^3.0.1"
   }
 }

--- a/producer.js
+++ b/producer.js
@@ -1,26 +1,27 @@
-var exports = module.exports;
-var request = require('sync-request');
-var kafka = require('kafka-node'),
-    // message = request('GET', 'http://spec.segment.com/generate/identify?pretty=true')
-    Producer = kafka.Producer,
-    KeyedMessage = kafka.KeyedMessage,
-    client = new kafka.Client(),
-    producer = new Producer(client),
-    km = new KeyedMessage('key', 'message')
-    // payloads = [
-    //     { topic: 'test', messages: message.getBody() }
-    // ];
+'use strict';
+
+const request = require('sync-request');
+const kafka = require('kafka-node');
+
+// message = request('GET', 'http://spec.segment.com/generate/identify?pretty=true')
+const Producer = kafka.Producer;
+const KeyedMessage = kafka.KeyedMessage;
+const client = new kafka.Client();
+const producer = new Producer(client);
+const km = new KeyedMessage('key', 'message');
+// payloads = [
+//     { topic: 'test', messages: message.getBody() }
+// ];
 
 exports.send = function(data){
   data = JSON.stringify(data)
   producer.send([{
     topic: 'test',
     messages: data
-  }], function (err, data) {
+  }], (err, data) => {
       console.log(data);
   });
-  producer.on('error', function (err) {
+  producer.on('error', err => {
     console.log(err)
   })
 }
-

--- a/producer.js
+++ b/producer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('sync-request');
+// const request = require('sync-request');
 const kafka = require('kafka-node');
 
 // message = request('GET', 'http://spec.segment.com/generate/identify?pretty=true')

--- a/server.js
+++ b/server.js
@@ -1,30 +1,30 @@
 'use strict';
-const Kafka = require('./producer.js')
+
+const Kafka = require('./producer.js');
 const Hapi = require('hapi');
+
 const server = new Hapi.Server();
 server.connection({ port: 8080 });
 
 server.route({
-    method: 'POST',
-    path: '/',
-    handler: function (request, reply) {
-        console.log(request.payload)
-        Kafka.send(request.payload)
-    }
+  method: 'POST',
+  path: '/',
+  handler(request, reply) {
+    console.log(request.payload)
+    Kafka.send(request.payload)
+  }
 });
 
 server.route({
-    method: 'GET',
-    path: '/',
-    handler: function (request, reply) {
-        reply('Hello, ' + encodeURIComponent(request.params.name) + '!');
-    }
+  method: 'GET',
+  path: '/',
+  handler(request, reply) {
+    reply(`Hello, ${encodeURIComponent(request.params.name)}!`);
+  }
 });
 
 server.start((err) => {
-
-    if (err) {
-        throw err;
-    }
-    console.log('Server running at:', server.info.uri);
+  if(err)
+    throw err;
+  console.log('Server running at:', server.info.uri);
 });


### PR DESCRIPTION
Hey, nothing too special 'bout this _PR_:
- I've added both `sync-request` and `kafka-node` as dependencies in [`package.json`](https://github.com/ythecombinator/kafka-node-quickstart/blob/master/package.json#L13) so I can just `npm install` all dependencies - as usual -, instead of installing them separately.
- I noticed you wrote parts of [`server.js`](https://github.com/ccnixon/kafka-node-quickstart/blob/master/server.js) using _ES6_ syntax - eg. `const` keyword -, but you didn't do the same with both `producer.js` and `consumer.js` files; so I just rewrote parts of them according to the _ES6_ syntax - making use of things like _arrow functions_ and _template strings_ -, to make things more standardized across the project.
- Last but not least; I put `node server.js` as `npm start` script, since many developers are used to run that one as a server fire up command.

BTW, thanks! I've started playing with _Apache Kafka_ these days and your project helped me understanding the _node.js_ integration process 😄 
